### PR TITLE
Tristan/atomics

### DIFF
--- a/src/join_set.rs
+++ b/src/join_set.rs
@@ -5,11 +5,12 @@ use std::{
     sync::Arc,
 };
 
-use tokio::{sync::{mpsc, Semaphore}, task::JoinSet as TokioJoinSet};
-
-use crate::{
-    AbortHandle, DispatcherResponse, Handle, JoinError, LocalSet,
+use tokio::{
+    sync::{mpsc, Semaphore},
+    task::JoinSet as TokioJoinSet,
 };
+
+use crate::{AbortHandle, DispatcherResponse, Handle, JoinError, LocalSet};
 
 pub struct JoinSet<T> {
     num_inactive_tasks: Arc<AtomicUsize>,
@@ -22,7 +23,6 @@ pub struct JoinSet<T> {
 
 impl<T> JoinSet<T> {
     pub fn new(concurrency: usize) -> Self {
-
         let (response_sender, response_receiver) = mpsc::unbounded_channel();
 
         Self {
@@ -118,7 +118,6 @@ impl<T: 'static> JoinSet<T> {
 
         //TODO: might be able to do normal abort handle
         AbortHandle
-
     }
 
     pub fn spawn_local_on<F>(&mut self, task: F, local_set: &LocalSet) -> AbortHandle

--- a/src/join_set.rs
+++ b/src/join_set.rs
@@ -6,30 +6,25 @@ use std::{
 };
 
 use tokio::{
-    sync::{mpsc, Semaphore},
+    sync::Semaphore,
     task::JoinSet as TokioJoinSet,
+    task::AbortHandle,
 };
 
-use crate::{AbortHandle, DispatcherResponse, Handle, JoinError, LocalSet};
+use crate::{Handle, JoinError, LocalSet};
 
 pub struct JoinSet<T> {
     num_inactive_tasks: Arc<AtomicUsize>,
     num_active_tasks: Arc<AtomicUsize>,
-    response_sender: mpsc::UnboundedSender<DispatcherResponse<T>>,
-    response_receiver: mpsc::UnboundedReceiver<DispatcherResponse<T>>,
     active_semaphore: Arc<Semaphore>,
-    inner_join_set: TokioJoinSet<()>,
+    inner_join_set: TokioJoinSet<T>,
 }
 
 impl<T> JoinSet<T> {
     pub fn new(concurrency: usize) -> Self {
-        let (response_sender, response_receiver) = mpsc::unbounded_channel();
-
         Self {
             num_inactive_tasks: Arc::new(AtomicUsize::new(0)),
             num_active_tasks: Arc::new(AtomicUsize::new(0)),
-            response_sender,
-            response_receiver,
             inner_join_set: TokioJoinSet::new(),
             active_semaphore: Arc::new(Semaphore::new(concurrency)),
         }
@@ -43,21 +38,21 @@ impl<T> JoinSet<T> {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    //TODO: add functions for getting num active, num inactive, num complete
 }
 impl<T: 'static> JoinSet<T> {
-    pub fn spawn<F>(&mut self, task: F) -> AbortHandle
-    where
-        F: Future<Output = T> + Send + 'static,
-        T: Send,
+    fn wrap_task<F>(&self, task: F) -> impl Future<Output = T> + 'static
+        where
+        F: Future<Output = T> + 'static,
     {
         self.num_inactive_tasks.fetch_add(1, Relaxed);
 
         let task_semaphore = self.active_semaphore.clone();
         let task_inactive_count = self.num_inactive_tasks.clone();
         let task_active_count = self.num_active_tasks.clone();
-        let task_response_channel = self.response_sender.clone();
 
-        let wrapped_task = async move {
+        async move {
             // SAFETY: error here means the semaphore is closed which is currently not logically possible
             let _permit = task_semaphore.acquire_owned().await.unwrap();
 
@@ -67,16 +62,45 @@ impl<T: 'static> JoinSet<T> {
 
             let output = task.await;
 
-            // TODO: confirm that ignoring this error is okay
-            _ = task_response_channel.send(DispatcherResponse { payload: output });
+            task_active_count.fetch_sub(1, Relaxed);
+
+            output
+        }
+    }
+
+    fn wrap_blocking_task<F>(&self, task: F) -> impl FnOnce() -> T + Send + 'static
+        where
+        F: FnOnce() -> T + Send + 'static,
+        T: Send,
+    {
+        self.num_inactive_tasks.fetch_add(1, Relaxed);
+        
+        let task_semaphore = self.active_semaphore.clone();
+        let task_inactive_count = self.num_inactive_tasks.clone();
+        let task_active_count = self.num_active_tasks.clone();
+
+        move || {
+            // SAFETY: error here means the semaphore is closed which is currently not logically possible
+            let _permit = task_semaphore.try_acquire_owned().unwrap(); //TODO: this does not work!!!!!! Need another way. Either spin loop or some blocking notifier
+
+            // TODO: consider a drop mechanism for these atomics for good cleanup on panic
+            task_inactive_count.fetch_sub(1, Relaxed);
+            task_active_count.fetch_add(1, Relaxed);
+
+            let output = task();
 
             task_active_count.fetch_sub(1, Relaxed);
-        };
 
-        self.inner_join_set.spawn(wrapped_task);
+            output
+        }
+    }
 
-        // TODO: might be able to just use regular abort handle
-        AbortHandle
+    pub fn spawn<F>(&mut self, task: F) -> AbortHandle
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send,
+    {
+        self.inner_join_set.spawn(self.wrap_task(task))
     }
 
     pub fn spawn_on<F>(&mut self, task: F, handle: &Handle) -> AbortHandle
@@ -84,47 +108,21 @@ impl<T: 'static> JoinSet<T> {
         F: Future<Output = T> + Send + 'static,
         T: Send,
     {
-        unimplemented!()
+        self.inner_join_set.spawn_on(self.wrap_task(task), handle)
     }
 
     pub fn spawn_local<F>(&mut self, task: F) -> AbortHandle
     where
         F: Future<Output = T> + 'static,
     {
-        self.num_inactive_tasks.fetch_add(1, Relaxed);
-
-        let task_semaphore = self.active_semaphore.clone();
-        let task_inactive_count = self.num_inactive_tasks.clone();
-        let task_active_count = self.num_active_tasks.clone();
-        let task_response_channel = self.response_sender.clone();
-
-        let wrapped_task = async move {
-            // SAFETY: error here means the semaphore is closed which is currently not logically possible
-            let _permit = task_semaphore.acquire_owned().await.unwrap();
-
-            // TODO: consider a drop mechanism for these atomics for good cleanup on panic
-            task_inactive_count.fetch_sub(1, Relaxed);
-            task_active_count.fetch_add(1, Relaxed);
-
-            let output = task.await;
-
-            // TODO: confirm that ignoring this error is okay
-            _ = task_response_channel.send(DispatcherResponse { payload: output });
-
-            task_active_count.fetch_sub(1, Relaxed);
-        };
-
-        self.inner_join_set.spawn_local(wrapped_task);
-
-        //TODO: might be able to do normal abort handle
-        AbortHandle
+        self.inner_join_set.spawn_local(self.wrap_task(task))
     }
 
     pub fn spawn_local_on<F>(&mut self, task: F, local_set: &LocalSet) -> AbortHandle
     where
         F: Future<Output = T> + 'static,
     {
-        unimplemented!()
+        self.inner_join_set.spawn_local_on(self.wrap_task(task), local_set)
     }
 
     pub fn spawn_blocking<F>(&mut self, f: F) -> AbortHandle
@@ -132,7 +130,7 @@ impl<T: 'static> JoinSet<T> {
         F: FnOnce() -> T + Send + 'static,
         T: Send,
     {
-        unimplemented!()
+        self.inner_join_set.spawn_blocking(self.wrap_blocking_task(f))
     }
 
     pub fn spawn_blocking_on<F>(&mut self, f: F, handle: &Handle) -> AbortHandle
@@ -140,21 +138,11 @@ impl<T: 'static> JoinSet<T> {
         F: FnOnce() -> T + Send + 'static,
         T: Send,
     {
-        unimplemented!()
+        self.inner_join_set.spawn_blocking_on(self.wrap_blocking_task(f), handle)
     }
 
     pub async fn join_next(&mut self) -> Option<Result<T, JoinError>> {
-        if self.is_empty() {
-            return None;
-        }
-
-        // wait on receive channel from dispatcher
-        let response = self.response_receiver.recv().await?;
-
-        // // decrement length counter
-        // self.num_tasks.fetch_sub(1, Relaxed);
-
-        Some(Ok(response.payload))
+        self.inner_join_set.join_next().await
     }
 
     pub async fn shutdown(&mut self) {


### PR DESCRIPTION
# Description
Complete Refactor which stops using dispatcher and uses a tokio semaphore to manage concurrency

### Issues
__This is impl is broken for spawn blocking!__ Will need to come up with a better way to do this in future


Also does not remove the dispatcher file even though it is not used. Will probably remove this later