### PR TITLE
Add `try_join_next` and `join_all`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["asynchronous"]
 keywords = ["tokio", "async", "non-blocking", "futures", "concurrency"]
 
 [dependencies]
-tokio = { version = "1.43", features = ["rt", "sync"] }
+tokio = { version = "1.42", features = ["rt", "sync"] }
 
 [dev-dependencies]
-tokio = { version = "1.43", features = ["macros", "time", "rt-multi-thread"] }
+tokio = { version = "1.42", features = ["macros", "time", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["asynchronous"]
 keywords = ["tokio", "async", "non-blocking", "futures", "concurrency"]
 
 [dependencies]
-tokio = { version = "1.42", features = ["rt", "sync"] }
+tokio = { version = "1.43", features = ["rt", "sync"] }
 
 [dev-dependencies]
-tokio = { version = "1.42", features = ["macros", "time", "rt-multi-thread"] }
+tokio = { version = "1.43", features = ["macros", "time", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,8 @@ A Concurrency-Limited JoinSet for Tokio.
 categories = ["asynchronous"]
 keywords = ["tokio", "async", "non-blocking", "futures", "concurrency"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-tokio = { version = "1.32", features = ["rt", "sync"] }
+tokio = { version = "1.43", features = ["rt", "sync"] }
 
 [dev-dependencies]
-tokio = { version = "1.32", features = ["macros", "time", "rt-multi-thread"] }
+tokio = { version = "1.43", features = ["macros", "time", "rt-multi-thread"] }

--- a/src/join_set.rs
+++ b/src/join_set.rs
@@ -121,7 +121,7 @@ impl<T: 'static> JoinSet<T> {
         self.inner_join_set.join_next().await
     }
 
-    pub async fn try_join_next(&mut self) -> Option<Result<T, JoinError>> {
+    pub fn try_join_next(&mut self) -> Option<Result<T, JoinError>> {
         self.inner_join_set.try_join_next()
     }
 

--- a/src/join_set.rs
+++ b/src/join_set.rs
@@ -121,6 +121,14 @@ impl<T: 'static> JoinSet<T> {
         self.inner_join_set.join_next().await
     }
 
+    pub async fn try_join_next(&mut self) -> Option<Result<T, JoinError>> {
+        self.inner_join_set.try_join_next()
+    }
+
+    pub async fn join_all(self) -> Vec<T> {
+        self.inner_join_set.join_all().await
+    }
+
     pub async fn shutdown(&mut self) {
         self.inner_join_set.shutdown().await;
     }
@@ -143,10 +151,6 @@ impl<T> Default for JoinSet<T> {
     fn default() -> Self {
         Self::new(8)
     }
-}
-
-impl<T> Drop for JoinSet<T> {
-    fn drop(&mut self) {}
 }
 
 impl<T> fmt::Debug for JoinSet<T> {


### PR DESCRIPTION
- Bumps tokio to 1.43
- Removes unnecessary `Drop` impl
- Adds `try_join_next` and `join_all` proxies